### PR TITLE
arm64: dts: hikey: Add ION entries to hikey dts

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts
+++ b/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts
@@ -93,6 +93,29 @@
 				};
 			};
 		};
+
+		hisi-ion@0 {
+			compatible = "hisilicon,ion";
+
+			heap_sys_user@0 {
+				heap-name = "sys_user";
+				heap-range = <0x0 0x0>;
+				heap-type = "ion_system";
+			};
+
+			heap_sys_contig@0 {
+				heap-name = "sys_contig";
+				heap-range = <0x0 0x0>;
+				heap-type = "ion_system_contig";
+			};
+
+			heap_cma@0 {
+				heap-name = "cma";
+				heap-range = <0x0 0x0>;
+				heap-type = "ion_cma";
+			};
+		};
+
 	};
 };
 


### PR DESCRIPTION
This patch adds ion entries to the hikey dts.

This was based off of the entries used in the 4.1 kernel

Signed-off-by: John Stultz john.stultz@linaro.org
