### PR TITLE
hikey: dts: Add pstore support for HiKey

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts
+++ b/arch/arm64/boot/dts/hisilicon/hi6220-hikey.dts
@@ -35,6 +35,7 @@
 	 *  0x05f0,1000 - 0x05f0,1fff: Reboot reason
 	 *  0x06df,f000 - 0x06df,ffff: Mailbox message data
 	 *  0x0740,f000 - 0x0740,ffff: MCU firmware section
+	 *  0x21f0,0000 - 0x21ff,ffff: pstore/ramoops buffer
 	 *  0x3e00,0000 - 0x3fff,ffff: OP-TEE
 	 */
 	memory@0 {
@@ -43,7 +44,21 @@
 		      <0x00000000 0x05f00000 0x00000000 0x00001000>,
 		      <0x00000000 0x05f02000 0x00000000 0x00efd000>,
 		      <0x00000000 0x06e00000 0x00000000 0x0060f000>,
-		      <0x00000000 0x07410000 0x00000000 0x36bf0000>;
+		      <0x00000000 0x07410000 0x00000000 0x1aaf0000>,
+		      <0x00000000 0x22000000 0x00000000 0x1c000000>;
+	};
+
+	pstore: pstore@0x21f00000 {
+		no-map;
+		reg = <0x0 0x21f00000 0x0 0x00100000>;  /* pstore/ramoops buffer */
+	};
+
+	ramoops {
+		compatible = "ramoops";
+		memory-region = <&pstore>;
+		record-size	= <0x0 0x00020000>;
+		console-size	= <0x0 0x00020000>;
+		ftrace-size	= <0x0 0x00020000>;
 	};
 
 	reboot_reason: reboot-reason@05f01000 {


### PR DESCRIPTION
This patch reserves some memory in the DTS and sets up a
pstore device tree node to enable pstore support on HiKey.

Signed-off-by: John Stultz john.stultz@linaro.org
