### PR TITLE
Hikey960 enable real eas model

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi3660-sched-energy.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hi3660-sched-energy.dtsi
@@ -1,69 +1,71 @@
 /*
- * Hikey960 dummy energy cost model data.
- *
- * XXX - This is inaccurate and needs work!
- *
+ * Hi3660 specific energy cost model data. There are no unit
+ * requirements for the data. Data can be normalized to any
+ * reference point, but the normalization must be consistent.
+ * That is, one bogo-joule/watt must be the same quantity for
+ * all data, but we don't care what it is.
  */
-
 
 energy-costs {
 	CPU_COST_A72: core-cost0 {
 		busy-cost-data = <
-			1023   616
-			 925   501
-			 827   426
-			 706   345
-			 557   259
-			 354   156
+			373    191
+			591    370
+			747    596
+			878    876
+			1023   1214
 		>;
 		idle-cost-data = <
-			0
-			0
+			50
+			50
+			15
 			0
 			0
 		>;
 	};
 	CPU_COST_A53: core-cost1 {
 		busy-cost-data = <
-			401   93
-			372   82
-			304   64
-			217   43
-			116   22
+			107    32
+			209    69
+			306    119
+			383    181
+			402    242
 		>;
 		idle-cost-data = <
-			0
+			14
+			14
 			0
 			0
 		>;
 	};
 	CLUSTER_COST_A72: cluster-cost0 {
 		busy-cost-data = <
-			1023   64
-			 925   55
-			 827   47
-			 706   38
-			 557   28
-			 354   17
+			373   128
+			591   176
+			747   233
+			878   308
+			1023  413
 		>;
 		idle-cost-data = <
-			0
-			0
-			0
+			150
+			150
+			150
+			150
 			0
 		>;
 	};
 	CLUSTER_COST_A53: cluster-cost1 {
 		busy-cost-data = <
-			401   57
-			372   50
-			304   39
-			217   26
-			116   13
+			107   16
+			209   28
+			306   44
+			383   64
+			402   84
 		>;
 		idle-cost-data = <
-			0
-			0
+			16
+			16
+			16
 			0
 		>;
 	};

--- a/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
@@ -261,12 +261,6 @@
 			opp-microvolt = <1100000>;
 			clock-latency-ns = <300000>;
 		};
-
-		opp15 {
-			opp-hz = /bits/ 64 <2612000000>;
-			opp-microvolt = <1100000>;
-			clock-latency-ns = <300000>;
-		};
 	};
 
 	gic: interrupt-controller@e82b0000 {


### PR DESCRIPTION
This patch series is to enable real eas energy model on Hikey960. And according to Hisilicon suggestion  to remove OPP 2.6GHz for big cluster. 