### PR TITLE
dts: hi3660: temporarily cut high OPPs for CA72

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
@@ -249,18 +249,6 @@
 			opp-microvolt = <900000>;
 			clock-latency-ns = <300000>;
 		};
-
-		opp13 {
-			opp-hz = /bits/ 64 <2112000000>;
-			opp-microvolt = <1000000>;
-			clock-latency-ns = <300000>;
-		};
-
-		opp14 {
-			opp-hz = /bits/ 64 <2362000000>;
-			opp-microvolt = <1100000>;
-			clock-latency-ns = <300000>;
-		};
 	};
 
 	gic: interrupt-controller@e82b0000 {


### PR DESCRIPTION
This is a temporary patch to cut high OPPs 2.11GHz and 2.36GHz so avoid
too high temperature to hurt board. After the thermal management has
been enabled, this patch should be reverted.

Signed-off-by: Leo Yan <leo.yan@linaro.org>