### PR TITLE
patcarm64: dts: temporarily limit big cluster to lowest frequency

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
@@ -237,30 +237,6 @@
 			opp-microvolt = <700000>;
 			clock-latency-ns = <300000>;
 		};
-
-		opp11 {
-			opp-hz = /bits/ 64 <1421000000>;
-			opp-microvolt = <800000>;
-			clock-latency-ns = <300000>;
-		};
-
-		opp12 {
-			opp-hz = /bits/ 64 <1805000000>;
-			opp-microvolt = <900000>;
-			clock-latency-ns = <300000>;
-		};
-
-		opp13 {
-			opp-hz = /bits/ 64 <2112000000>;
-			opp-microvolt = <1000000>;
-			clock-latency-ns = <300000>;
-		};
-
-		opp14 {
-			opp-hz = /bits/ 64 <2362000000>;
-			opp-microvolt = <1100000>;
-			clock-latency-ns = <300000>;
-		};
 	};
 
 	gic: interrupt-controller@e82b0000 {


### PR DESCRIPTION
This patch is to limit Hikey960 big cluster frequency to 903MHz so avoid too high temperature.