### PR TITLE
clk: hisilicon: fix lock assignment

### DIFF
--- a/drivers/clk/hisilicon/clkgate-separated.c
+++ b/drivers/clk/hisilicon/clkgate-separated.c
@@ -120,6 +120,7 @@ struct clk *hisi_register_clkgate_sep(struct device *dev, const char *name,
 	sclk->bit_idx = bit_idx;
 	sclk->flags = clk_gate_flags;
 	sclk->hw.init = &init;
+	sclk->lock = lock;
 
 	clk = clk_register(dev, &sclk->hw);
 	if (IS_ERR(clk))


### PR DESCRIPTION
In clock driver initialize phase the spinlock is missed to assignment
to struct clkgate_separated, finally there have no locking to protect
exclusive accessing for clock registers.

This bug introduces the console has no output after enable coresight
driver on 96boards Hikey; this is because console using UART3, which
has shared the same register with coresight clock enabling bit. After
applied this patch it can assign lock properly to protect exclusive
accessing, and console can work well after enabled coresight modules.

Fixes: 0aa0c95f743a ("clk: hisilicon: add common clock support")
Signed-off-by: Leo Yan <leo.yan@linaro.org>
Signed-off-by: Stephen Boyd <sboyd@codeaurora.org>