### PR TITLE
Hikey960 v4.4 fixing stub clock

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
@@ -103,7 +103,7 @@
 		};
 
 		cpu4: cpu@100 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x100>;
 			enable-method = "psci";
@@ -115,7 +115,7 @@
 		};
 
 		cpu5: cpu@101 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x101>;
 			enable-method = "psci";
@@ -127,7 +127,7 @@
 		};
 
 		cpu6: cpu@102 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x102>;
 			enable-method = "psci";
@@ -139,7 +139,7 @@
 		};
 
 		cpu7: cpu@103 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x103>;
 			enable-method = "psci";

--- a/drivers/clk/hisilicon/clk-hi3660-stub.c
+++ b/drivers/clk/hisilicon/clk-hi3660-stub.c
@@ -68,6 +68,7 @@ struct hi3660_stub_clk {
 	u32 table_len;
 
 	u32 rate;
+	unsigned int msg[8];
 
 	struct hi3660_stub_clk_chan *chan;
 };
@@ -166,15 +167,14 @@ static int hi3660_stub_clk_set_rate(struct clk_hw *hw, unsigned long rate,
 {
 	struct hi3660_stub_clk *stub_clk =
 		container_of(hw, struct hi3660_stub_clk, hw);
-	unsigned int msg[8];
 
-	msg[0] = stub_clk->set_rate_cmd;
-	msg[1] = rate / 1000000;
+	stub_clk->msg[0] = stub_clk->set_rate_cmd;
+	stub_clk->msg[1] = rate / 1000000;
 
 	pr_debug("%s: set_rate_cmd[0] %x [1] %x\n", __func__,
-		msg[0], msg[1]);
+		stub_clk->msg[0], stub_clk->msg[1]);
 
-	mbox_send_message(stub_clk->chan->mbox, msg);
+	mbox_send_message(stub_clk->chan->mbox, stub_clk->msg);
 	stub_clk->rate = rate;
 	return 0;
 }
@@ -262,7 +262,7 @@ static int hi3660_stub_clk_probe(struct platform_device *pdev)
 	/* Use mailbox client with blocking mode */
 	chan->cl.dev = dev;
 	chan->cl.tx_done = NULL;
-	chan->cl.tx_block = true;
+	chan->cl.tx_block = false;
 	chan->cl.tx_tout = 500;
 	chan->cl.knows_txdone = false;
 


### PR DESCRIPTION
This patch set has two fixings, one is to fix CPU type for CA73; another is to fix stub clock driver to use stub clock driver structure to store message for mailbox, as result the second patch is to fix the mailbox failure issue.