### PR TITLE
Working android hikey linaro 4.4 hifi dsp push

### DIFF
--- a/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
+++ b/arch/arm64/boot/dts/hisilicon/hi3660.dtsi
@@ -103,7 +103,7 @@
 		};
 
 		cpu4: cpu@100 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x100>;
 			enable-method = "psci";
@@ -115,7 +115,7 @@
 		};
 
 		cpu5: cpu@101 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x101>;
 			enable-method = "psci";
@@ -127,7 +127,7 @@
 		};
 
 		cpu6: cpu@102 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x102>;
 			enable-method = "psci";
@@ -139,7 +139,7 @@
 		};
 
 		cpu7: cpu@103 {
-			compatible = "arm,cortex-a72", "arm,armv8";
+			compatible = "arm,cortex-a73", "arm,armv8";
 			device_type = "cpu";
 			reg = <0x0 0x103>;
 			enable-method = "psci";

--- a/drivers/clk/hisilicon/clk-hi3660-stub.c
+++ b/drivers/clk/hisilicon/clk-hi3660-stub.c
@@ -68,6 +68,7 @@ struct hi3660_stub_clk {
 	u32 table_len;
 
 	u32 rate;
+	unsigned int msg[8];
 
 	struct hi3660_stub_clk_chan *chan;
 };
@@ -166,15 +167,14 @@ static int hi3660_stub_clk_set_rate(struct clk_hw *hw, unsigned long rate,
 {
 	struct hi3660_stub_clk *stub_clk =
 		container_of(hw, struct hi3660_stub_clk, hw);
-	unsigned int msg[8];
 
-	msg[0] = stub_clk->set_rate_cmd;
-	msg[1] = rate / 1000000;
+	stub_clk->msg[0] = stub_clk->set_rate_cmd;
+	stub_clk->msg[1] = rate / 1000000;
 
 	pr_debug("%s: set_rate_cmd[0] %x [1] %x\n", __func__,
-		msg[0], msg[1]);
+		stub_clk->msg[0], stub_clk->msg[1]);
 
-	mbox_send_message(stub_clk->chan->mbox, msg);
+	mbox_send_message(stub_clk->chan->mbox, stub_clk->msg);
 	stub_clk->rate = rate;
 	return 0;
 }
@@ -262,7 +262,7 @@ static int hi3660_stub_clk_probe(struct platform_device *pdev)
 	/* Use mailbox client with blocking mode */
 	chan->cl.dev = dev;
 	chan->cl.tx_done = NULL;
-	chan->cl.tx_block = true;
+	chan->cl.tx_block = false;
 	chan->cl.tx_tout = 500;
 	chan->cl.knows_txdone = false;
 

--- a/drivers/hisi/hifidsp/Makefile
+++ b/drivers/hisi/hifidsp/Makefile
@@ -33,5 +33,6 @@ endif
 
 obj-$(CONFIG_HIFI_DSP_ONE_TRACK)	+= hifi_lpp.o
 obj-$(CONFIG_HIFI_DSP_ONE_TRACK)	+= hifi_om.o
+obj-$(CONFIG_HIFI_DSP_ONE_TRACK)	+= memcpy_opt.o
 
 

--- a/drivers/hisi/hifidsp/hifi_lpp.c
+++ b/drivers/hisi/hifidsp/hifi_lpp.c
@@ -1657,8 +1657,6 @@ void reset_audio_clk_work(struct work_struct *work)
 static int hifi_misc_probe (struct platform_device *pdev)
 {
 	int ret = OK;
-    unsigned char *dspon,*dsploadindicate;
-    int *ptr; 
 
 	IN_FUNCTION;
     printk("Cadence_Linaro_Debug Entered %s\n",__func__);
@@ -1677,19 +1675,6 @@ static int hifi_misc_probe (struct platform_device *pdev)
 	s_hifi_reboot_nb.priority = -1;
 	(void)register_reboot_notifier(&s_hifi_reboot_nb);
 
-dspon=(unsigned char*)ioremap_wc(DRV_DSP_POWER_STATUS_ADDR, 0x4);
-dsploadindicate=(unsigned char*)ioremap_wc(DRV_DSP_LOADED_INDICATE, 0x4);
-ptr=dspon;
-*ptr=DRV_DSP_POWER_ON;
-printk("Cadence_Linaro_Debug dspon0x%x\n",*ptr);
-ptr=dsploadindicate;
-*ptr=0x0;
-printk("Cadence_Linaro_Debug dspon0x%x\n",*ptr);
-if ((NULL != dspon) &&(NULL != dsploadindicate)) {
-    printk("Cadence_Linaro_Debug iounmap\n");
-	iounmap(dspon);
-	iounmap(dsploadindicate);
-}
 	s_misc_data.hifi_priv_base_virt = (unsigned char*)ioremap_wc(HIFI_BASE_ADDR, HIFI_UNSEC_REGION_SIZE);
 
 

--- a/drivers/hisi/hifidsp/hifi_lpp.h
+++ b/drivers/hisi/hifidsp/hifi_lpp.h
@@ -18,7 +18,23 @@ extern "C" {
 #endif
 
 #include <linux/list.h>
-#include "global_ddr_map.h"
+//lwp:no need include global_ddr_map.h, just define hifi's address config here
+//#include "global_ddr_map.h"
+
+//Added to avoid the crash
+#define CONFIG_HISI_FAMA
+
+#ifdef  CONFIG_HISI_FAMA
+#define HISI_RESERVED_HIFI_PHYMEM_BASE_FAMA              0x5A8900000
+#endif
+#define HISI_RESERVED_HIFI_PHYMEM_BASE                   0x88900000
+#define HISI_RESERVED_HIFI_PHYMEM_SIZE                   (0x980000)
+
+#ifdef  CONFIG_HISI_FAMA
+#define HISI_RESERVED_HIFI_DATA_PHYMEM_BASE_FAMA         0x5AAA00000
+#endif
+#define HISI_RESERVED_HIFI_DATA_PHYMEM_BASE              0x8AA00000
+#define HISI_RESERVED_HIFI_DATA_PHYMEM_SIZE              (0x380000)
 
 /* mailbox mail_len max */
 #define MAIL_LEN_MAX	(512)
@@ -47,34 +63,36 @@ extern "C" {
 #ifdef CONFIG_HISI_FAMA
 #define HIFI_BASE_ADDR                      (HISI_RESERVED_HIFI_DATA_PHYMEM_BASE_FAMA)
 #else
-//#define HIFI_BASE_ADDR                      (0x8AA00000)
+#define HIFI_BASE_ADDR                      (HISI_RESERVED_HIFI_DATA_PHYMEM_BASE)
 #endif
 
-#define HIFI_BASE_ADDR 0x5AAA00000ULL
+#ifdef CONFIG_HISI_FAMA
+#define HIFI_SECDDR_BASE_ADDR                  (HISI_RESERVED_HIFI_PHYMEM_BASE_FAMA)
+#else
+#define HIFI_SECDDR_BASE_ADDR                  (HISI_RESERVED_HIFI_PHYMEM_BASE)
+#endif
 
-//Kirin960
-/** secure region 9.5M ,nyadla modified based on kirin955 **/
-/* |~~~0x88900000~~~|~~~0x88930000~~~|~~~0x8894E000~~|~~~0x88D4E000~~~|~~~0x88D80000~~~| */
-/* |~OCRAM img bak~~|~~TCM img bak~~|~~~~IMG bak~~~~~|~~~sec reserve~~|~~HIFI RUNNING~~| */
-/* |~~~~~~192K~~~~~~|~~~~~120k~~~~~~|~~~~~~~4M ~~~~~~|~~~~~200k~~~~~~~|~~~~~~~5M~~~~~~~| */
-/* |~~~0x8892FFFF~~~|~~~0x8894DFFF~~|~~~0x88D4DFFF~~~|~~~0x88D7FFFF~~~|~~~0x89280000~~~| */
+/** for chicago only **/
+/** unsecured region 3.5M **/
+/* |~0x8AA00000~|~0x8AB32000~|~0x8AC32000~|~0x8ACB1000~|~0x8ACB2000~|~0x8ACC5000~|~0x8ACC6000~|~0x8ACC7000~|~0x8ACF9800~|~0x8AD09800~~| */
+/* |~Music data~|~~~PCM data~|~~hifi uart~|~panic stack|~icc debug~~|~flag data ~|DDR sec head|~~~AP NV ~~~|~AP&HIFI MB~|unsec reserve| */
+/* |~~~~~1.2M~~~|~~~~~1M~~~~~|~~~508k~~~~~|~~~~~~4k~~~~|~~~~76k~~~~~|~~~~~4k~~~~~|~~~~~4k~~~~~|~~~~202k~~~~|~~~~~64k~~~~|~~~~474k~~~~~| */
+/* |~0x8AB31fff~|~0x8AC31fff~|~0x8ACB0fff~|~0x8ACB1fff~|~0x8ACC4fff~|~0x8ACC5fff~|~0x8ACC6fff~|~0x8ACF97ff~|~0x8AD097ff~|~~0x8AD7ffff~| */
 
-/** unsecure region 3.5M,nyadla modified based on kirin955 **/
-/* |~0x8AA00000~|~0x8AB32000~|~0x8AC32000~|~0x8ACB1000~|~0x8ACB2000~|~0x8ACC5000~|~0x8AD2D000~|~~0x8AD2E000~~|~0x8AD2F000~|~0x8AD61800~|~~0x8AD71800~~|  */
-/* |~Music data~|~~~PCM data~|~~hifi uart~|~panic stack|~icc debug~~|~~~OM log~~~|~flag data ~|~DDR sec head~|~~~AP NV ~~~|~AP&HIFI MB~|~unsec reserve|  */
-/* |~~~~~1.2M~~~|~~~~~1M~~~~~|~~~508k~~~~~|~~~~~~4k~~~~|~~~~76k~~~~~|~~~~416k~~~~|~~~~~4k~~~~~|~~~~~~4k~~~~~~|~~~~202k~~~~|~~~~~64k~~~~|~~~~~~58k~~~~~|  */
-/* |~0x8AB31FFF~|~0x8AC31FFF~|~0x8ACB0FFF~|~0x8ACB1FFF~|~0x8ACC4FFF~|~0x8AD2CFFF~|~0x8AD2DFFF~|~~0x8AD2EFFF~~|~0x8AD617FF~|~0x8AD717FF~|~~0x8AD7FFFF~~|  */
+/** security region 9.5M **/
+/* |~~~0x88900000~~~|~~~0x88f00000~~~|~~~0x88f30000~~|~~~0x88f64000~~~| */
+/* |~~HIFI RUNNING~~|~OCRAM img bak~~|~~TCM img bak~~|~~~~IMG bak~~~~~| */
+/* |~~~~~~~6M~~~~~~~|~~~~~~192K~~~~~~|~~~~~208k~~~~~~|~~~~~~3.1M ~~~~~| */
+/* |~~~0x88efffff~~~|~~~0x88f2ffff~~~|~~~0x88f63fff~~|~~~0x89280000~~~| */
 
+/** for kirin950 **/
+/** unsecured region 3.5M **/
+/* |~0x34f00000~|~0x35032000~|~0x35132000~|~0x351b1000~|~0x351b2000~|~0x351c5000~|~~0x351c6000~~|~0x351c7000~|~0x351f9800~|~~0x35209800~~| */
+/* |~Music data~|~~~PCM data~|~~hifi uart~|~panic stack|~icc debug~~|~flag data ~|~DDR sec head~|~~~AP NV ~~~|~AP&HIFI MB~|~unsec reserve| */
+/* |~~~~~1.2M~~~|~~~~~1M~~~~~|~~~508k~~~~~|~~~~~~4k~~~~|~~~~76k~~~~~|~~~~~4k~~~~~|~~~~~~4k~~~~~~|~~~~202k~~~~|~~~~~64k~~~~|~~~~~~474k~~~~| */
+/* |~0x35031fff~|~0x35131fff~|~0x351b0fff~|~0x351b1fff~|~0x351c4fff~|~0x351c5fff~|~~0x351c6fff~~|~0x351f97ff~|~0x352097ff~|~~~0x3527ffff~| */
 
-//Kirin955
-/** unsecure region 3.5M **/
-/* |~0x34f00000~|~0x35032000~|~0x35132000~|~0x351b1000~|~0x351b2000~|~0x351c5000~|~0x3522d000~|~~0x3522e000~~|~0x3522f000~|~0x35261800~|~~0x35271800~~| */
-/* |~Music data~|~~~PCM data~|~~hifi uart~|~panic stack|~icc debug~~|~~~OM log~~~|~flag data ~|~DDR sec head~|~~~AP NV ~~~|~AP&HIFI MB~|~unsec reserve| */
-/* |~~~~~1.2M~~~|~~~~~1M~~~~~|~~~508k~~~~~|~~~~~~4k~~~~|~~~~76k~~~~~|~~~~416k~~~~|~~~~~4k~~~~~|~~~~~~4k~~~~~~|~~~~202k~~~~|~~~~~64k~~~~|~~~~~~58k~~~~~| */
-/* |~0x35031fff~|~0x35131fff~|~0x351b0fff~|~0x351b1fff~|~0x351c4fff~|~0x3522cfff~|~0x3522dfff~|~~0x3522efff~~|~0x352617ff~|~0x352717ff~|~~~0x3527ffff~| */
-
-
-/** secure region 9.5M **/
+/** security region 9.5M **/
 /* |~~~0x35280000~~~|~~~0x352b0000~~|~~~0x352ce000~~~|~~~0x356ce000~~~|~~~0x35700000~~~| */
 /* |~OCRAM img bak~~|~~TCM img bak~~|~~~~IMG bak~~~~~|~~~sec reserve~~|~~HIFI RUNNING~~| */
 /* |~~~~~~192K~~~~~~|~~~~~120k~~~~~~|~~~~~~~4M ~~~~~~|~~~~~200k~~~~~~~|~~~~~~~5M~~~~~~~| */
@@ -95,21 +113,20 @@ extern "C" {
 #define DRV_DSP_UART_TO_MEM_RESERVE_SIZE    (0x100)
 #define DRV_DSP_STACK_TO_MEM_SIZE           (0x1000)
 #define HIFI_ICC_DEBUG_SIZE                 (0x13000)
-#define HIFI_OM_LOG_SIZE                    (0x68000)
+
 #define HIFI_FLAG_DATA_SIZE                 (0x1000)
 #define HIFI_SEC_HEAD_SIZE                  (0x1000)
 #define HIFI_AP_NV_DATA_SIZE                (0x32800)
 #define HIFI_AP_MAILBOX_TOTAL_SIZE          (0x10000)
 #define HIFI_UNSEC_RESERVE_SIZE             (0xe800)
-
+#define HIFI_FLAG_DATA_ADDR             (HIFI_ICC_DEBUG_LOCATION + HIFI_ICC_DEBUG_SIZE)
 #define HIFI_UNSEC_BASE_ADDR            (HIFI_BASE_ADDR)
 #define HIFI_MUSIC_DATA_LOCATION        (HIFI_UNSEC_BASE_ADDR)
 #define PCM_PLAY_BUFF_LOCATION          (HIFI_MUSIC_DATA_LOCATION + HIFI_MUSIC_DATA_SIZE)
 #define DRV_DSP_UART_TO_MEM             (PCM_PLAY_BUFF_LOCATION + PCM_PLAY_BUFF_SIZE)
 #define DRV_DSP_STACK_TO_MEM            (DRV_DSP_UART_TO_MEM + DRV_DSP_UART_TO_MEM_SIZE)
 #define HIFI_ICC_DEBUG_LOCATION         (DRV_DSP_STACK_TO_MEM + DRV_DSP_STACK_TO_MEM_SIZE)
-#define HIFI_OM_LOG_ADDR                (HIFI_ICC_DEBUG_LOCATION + HIFI_ICC_DEBUG_SIZE)
-#define HIFI_FLAG_DATA_ADDR             (HIFI_OM_LOG_ADDR + HIFI_OM_LOG_SIZE)
+
 #define HIFI_SEC_HEAD_BACKUP            (HIFI_FLAG_DATA_ADDR + HIFI_FLAG_DATA_SIZE)
 #define HIFI_AP_NV_DATA_ADDR            (HIFI_SEC_HEAD_BACKUP + HIFI_SEC_HEAD_SIZE)
 #define HIFI_AP_MAILBOX_BASE_ADDR       (HIFI_AP_NV_DATA_ADDR + HIFI_AP_NV_DATA_SIZE)
@@ -139,25 +156,50 @@ extern "C" {
 #define HIFI_SEC_REGION_SIZE            (0x980000)
 #define HIFI_IMAGE_OCRAMBAK_SIZE        (0x30000)
 #ifdef HIFI_TCM_208K
+#define HIFI_RUN_SIZE                   (0x600000)
 #define HIFI_IMAGE_TCMBAK_SIZE          (0x34000)
-#define HIFI_IMAGE_SIZE                 (0x3ea000)
+#define HIFI_IMAGE_SIZE                 (0x31C000)
+#define HIFI_RUN_ITCM_BASE              (0xe8080000)
+#define HIFI_RUN_ITCM_SIZE              (0x9000)
+#define HIFI_RUN_DTCM_BASE              (0xe8058000)
+#define HIFI_RUN_DTCM_SIZE              (0x28000)
 #else
+#define HIFI_RUN_SIZE                   (0x500000)
 #define HIFI_IMAGE_TCMBAK_SIZE          (0x1E000)
 #define HIFI_IMAGE_SIZE                 (0x400000)
-#endif
 #define HIFI_SEC_RESERVE_SIZE           (0x32000)
-#define HIFI_RUN_SIZE                   (0x500000)
+#define HIFI_RUN_ITCM_BASE              (0xe8070000)
+#define HIFI_RUN_ITCM_SIZE              (0x6000)
+#define HIFI_RUN_DTCM_BASE              (0xe8058000)
+#define HIFI_RUN_DTCM_SIZE              (0x18000)
+#endif
 
-//#define HIFI_SEC_REGION_ADDR            (0x88900000)
-#define HIFI_SEC_REGION_ADDR 5A8900000ULL
+#ifdef HIFI_TCM_208K
+#define HIFI_SEC_REGION_ADDR            (HIFI_SECDDR_BASE_ADDR) /* chciago */
+#define HIFI_RUN_LOCATION               (HIFI_SEC_REGION_ADDR)
+#define HIFI_IMAGE_OCRAMBAK_LOCATION    (HIFI_RUN_LOCATION + HIFI_RUN_SIZE)
+#define HIFI_IMAGE_TCMBAK_LOCATION      (HIFI_IMAGE_OCRAMBAK_LOCATION + HIFI_IMAGE_OCRAMBAK_SIZE)
+#define HIFI_IMAGE_LOCATION             (HIFI_IMAGE_TCMBAK_LOCATION + HIFI_IMAGE_TCMBAK_SIZE)
+#else
+#define HIFI_SEC_REGION_ADDR            (HIFI_BASE_ADDR + HIFI_UNSEC_REGION_SIZE) /* austin dallas */
 #define HIFI_IMAGE_OCRAMBAK_LOCATION    (HIFI_SEC_REGION_ADDR)
 #define HIFI_IMAGE_TCMBAK_LOCATION      (HIFI_IMAGE_OCRAMBAK_LOCATION + HIFI_IMAGE_OCRAMBAK_SIZE)
 #define HIFI_IMAGE_LOCATION             (HIFI_IMAGE_TCMBAK_LOCATION + HIFI_IMAGE_TCMBAK_SIZE)
 #define HIFI_SEC_RESERVE_ADDR           (HIFI_IMAGE_LOCATION + HIFI_IMAGE_SIZE)
 #define HIFI_RUN_LOCATION               (HIFI_SEC_RESERVE_ADDR + HIFI_SEC_RESERVE_SIZE)
+#endif
 
 #define HIFI_OCRAM_BASE_ADDR                    (0xE8000000)
 #define HIFI_TCM_BASE_ADDR                      (0xE8058000)
+#define HIFI_RUN_DDR_REMAP_BASE         (0xC0000000)
+
+#define HIFI_TCM_PHY_BEGIN_ADDR         (HIFI_TCM_BASE_ADDR)
+#define HIFI_TCM_PHY_END_ADDR           (HIFI_TCM_PHY_BEGIN_ADDR + HIFI_TCM_SIZE - 1)
+#define HIFI_TCM_SIZE                   (HIFI_RUN_ITCM_SIZE + HIFI_RUN_DTCM_SIZE)
+
+#define HIFI_OCRAM_PHY_BEGIN_ADDR       (HIFI_OCRAM_BASE_ADDR)
+#define HIFI_OCRAM_PHY_END_ADDR         (HIFI_OCRAM_PHY_BEGIN_ADDR + HIFI_OCRAM_SIZE - 1)
+#define HIFI_OCRAM_SIZE                 (HIFI_IMAGE_OCRAMBAK_SIZE)
 
 #define SIZE_PARAM_PRIV                         (206408) /*refer from function dsp_nv_init in dsp_soc_para_ctl.c  */
 #define HIFI_SYS_MEM_ADDR                       (HIFI_RUN_LOCATION)

--- a/drivers/hisi/hifidsp/hifi_om.c
+++ b/drivers/hisi/hifidsp/hifi_om.c
@@ -34,8 +34,10 @@
 #include "hifi_lpp.h"
 #include "hifi_om.h"
 #include "drv_mailbox_msg.h"
+#include <linux/hisi/hisi_rproc.h>
 #include "dsm_pub.h"
 #include <linux/hisi/rdr_pub.h>
+#include <linux/delay.h>
 
 #ifdef __cplusplus
 #if __cplusplus
@@ -371,7 +373,7 @@ static void hifi_om_show_audio_detect_info(struct work_struct *work)
 		break;
 	case HIFI_CPU_OM_ALGO_MCPS_INFO:
 		if ((sizeof(mcps_info)) != data_len) {
-			logw("unavailable data from hifi, data_len: %u\n");
+			logw("unavailable data from hifi, data_len: %u\n", data_len);
 			return;
 		}
 		memcpy(&mcps_info, data, sizeof(mcps_info));
@@ -380,7 +382,7 @@ static void hifi_om_show_audio_detect_info(struct work_struct *work)
 		break;
 	case HIFI_CPU_OM_UPDATE_BUFF_DELAY_INFO:
 		if ((sizeof(update_buff_delay_info)) != data_len) {
-			logw("unavailable data from hifi, data_len: %u\n");
+			logw("unavailable data from hifi, data_len: %u\n", data_len);
 			return;
 		}
 		memcpy(&update_buff_delay_info, data, sizeof(update_buff_delay_info));
@@ -800,6 +802,246 @@ static const struct file_operations hifi_dspfaultinject_proc_ops = {
 	.write = hifi_dsp_fault_inject_store,
 };
 
+struct image_partition_table addr_remap_tables[] =
+{
+	{HIFI_RUN_DDR_REMAP_BASE, HIFI_RUN_DDR_REMAP_BASE + HIFI_RUN_SIZE, HIFI_RUN_SIZE, HIFI_RUN_LOCATION},
+	{HIFI_TCM_PHY_BEGIN_ADDR, HIFI_TCM_PHY_END_ADDR, HIFI_TCM_SIZE, HIFI_IMAGE_TCMBAK_LOCATION},
+	{HIFI_OCRAM_PHY_BEGIN_ADDR, HIFI_OCRAM_PHY_END_ADDR, HIFI_OCRAM_SIZE, HIFI_IMAGE_OCRAMBAK_LOCATION}
+};
+extern void *memcpy64(void *dst, const void *src, unsigned len);
+extern void *memcpy128(void *dst, const void *src, unsigned len);
+
+void *memcpy_aligned(void *_dst, const void *_src, unsigned len)
+{
+	unsigned char *dst = _dst;
+	const unsigned char *src = _src;
+	unsigned int length = len;
+	unsigned int cpy_len;
+
+	if (((unsigned long)dst % 16 == 0) && ((unsigned long)src % 16 == 0) && (length >= 16)) {
+		cpy_len = length&0xFFFFFFF0;
+		memcpy128(dst, src, cpy_len);
+		length = length % 16;
+		dst = dst + cpy_len;
+		src = src + cpy_len;
+
+		if(0 == length)
+			return _dst;
+	}
+
+	if (((unsigned long)dst % 8 == 0) && ((unsigned long)src % 8 == 0) && (length >= 8)) {
+		cpy_len = length & 0xFFFFFFF8;
+		memcpy64(dst, src, cpy_len);
+		length = length % 8;
+		dst = dst + cpy_len;
+		src = src + cpy_len;
+		if(0 == length)
+			return _dst;
+	}
+
+	if (((unsigned long)dst % 4 == 0) && ((unsigned long)src % 4 == 0)){
+		cpy_len = length >> 2;
+		while(cpy_len-- > 0) {
+			*(unsigned int *)dst = *(unsigned int *)src; //lint !e826
+			dst += 4;
+			src += 4;
+		}
+		length = length % 4;
+		if(0 == length)
+			return _dst;
+	}
+
+	while(length-- > 0){
+		*dst++ = *src++;
+	}
+
+	return _dst;
+}
+
+#define CMD_TO_LPM3_POWEROFF_HIFI ((0 << 24) | (16 << 16) | (3 << 8) | (1 << 0))
+
+static int notify_lpm3_power_off_hifi(void)
+{
+	int ret = 0;
+	unsigned int msg = CMD_TO_LPM3_POWEROFF_HIFI;
+
+	ret = RPROC_ASYNC_SEND(HISI_RPROC_LPM3_MBX17, &msg, 1);
+	if (ret)
+		loge("send message to lpm3 fail\n");
+
+	return ret;
+}
+
+#define HIFI_IMAGE_PATH "/data/hifi.img"
+static int read_hifi_img_file(char *img_buf)
+{
+	int fd = 0;
+	unsigned int img_size = 0;
+	unsigned int read_size = 0;
+	int ret = 0;
+	mm_segment_t old_fs;
+	struct drv_hifi_image_head *img_head = NULL;
+
+	if (!img_buf) {
+		loge("img buffer is null\n");
+		return -1;
+	}
+
+	old_fs = get_fs();
+	set_fs(KERNEL_DS);/*lint !e501*/
+
+	fd = sys_open(HIFI_IMAGE_PATH, O_RDONLY, HIFI_OM_FILE_LIMIT);
+	if (fd < 0) {
+		loge("open %s failed, fd:%d\n", HIFI_IMAGE_PATH, fd);
+		set_fs(old_fs);
+		return -1;
+	}
+
+	img_head = (struct drv_hifi_image_head *)vzalloc(sizeof(struct drv_hifi_image_head) + 1);
+	if (!img_head) {
+		loge("alloc img buffer fail\n");
+		ret = -1;
+		goto end;
+	}
+
+	read_size = sys_read((unsigned int)fd, (char *)img_head, sizeof(struct drv_hifi_image_head));
+	if (read_size != sizeof(struct drv_hifi_image_head)) {
+		loge("read image head failed, read size:%u\n", read_size);
+		vfree(img_head);
+		ret = -1;
+		goto end;
+	}
+
+	img_size = img_head->image_size;
+	vfree(img_head);
+
+	if (sys_lseek((unsigned int)fd, 0, SEEK_SET)) {
+		loge("lseek fail\n");
+		ret = -1;
+		goto end;
+	}
+
+	read_size = sys_read((unsigned int)fd, (char *)img_buf, img_size);
+	if (read_size != img_size) {
+		loge("read total image file failed, read size:%u, image size:%u\n",
+			read_size, img_size);
+		ret = -1;
+		goto end;
+	}
+
+end:
+	sys_close(fd);
+	set_fs(old_fs);
+
+	return ret;
+}
+
+
+static int read_hifi_shared_addr(void)
+{
+	unsigned int *read_hifi_shared_addr = NULL;
+	int ret = 0;
+    loge(" %s():Enter \n",__func__);
+    //If we put 0x8ACC5000 addr kernel panic is observed at ioremap.c line no:58 ./arch/arm64/mm/ioremap.c.
+    read_hifi_shared_addr = ioremap_wc(0x5AACC5000,50);
+    if ( NULL == read_hifi_shared_addr ) {
+		loge(" %s(): read_hifi_shared_addr ioremap_wc failed\n", __func__);
+	}
+	else {
+        loge(" 0x8ACC5000:0x%x \n",readl(read_hifi_shared_addr) );
+
+        //sleep for 2 secs
+        loge(" %s(): Waiting for 2 secs\n",__func__);
+        msleep(2000);
+
+        loge(" 0x8ACF9800:0x%x\n",readl(read_hifi_shared_addr));
+
+		iounmap(read_hifi_shared_addr);
+		read_hifi_shared_addr = NULL;
+	}
+	loge(" %s():Exit\n",__func__);
+	return ret;
+}
+
+
+
+static int load_hifi_img_by_misc(void)
+{
+	unsigned int i = 0;
+	char *img_buf = NULL;
+	struct drv_hifi_image_head *hifi_img = NULL;
+
+	loge("load hifi image now\n");
+
+	if (notify_lpm3_power_off_hifi()) {
+		loge("power off hifi fail\n");
+		return -1;
+	}
+
+	img_buf = (char *)vzalloc(HIFI_IMAGE_SIZE);
+	if (!img_buf) {
+		loge("alloc img buffer fail\n");
+		return -1;
+	}
+
+	if (read_hifi_img_file(img_buf)) {
+		loge("read hifi img fail\n");
+		vfree(img_buf);
+		return -1;
+	}
+
+	hifi_img = (struct drv_hifi_image_head *)img_buf;
+	logi("sections_num:%u, image_size:%u\n", hifi_img->sections_num, hifi_img->image_size);
+
+	for (i = 0; i < hifi_img->sections_num; i++) {
+		unsigned int index = 0;
+		unsigned long remap_dest_addr = 0;
+		logi("sections_num:%u, i:%u\n",hifi_img->sections_num,i);
+		logi("des_addr:0x%x, load_attib:%u, size:%u, sn:%hu, src_offset:%x, type:%u\n", \
+						hifi_img->sections[i].des_addr,\
+						hifi_img->sections[i].load_attib,\
+						hifi_img->sections[i].size,\
+						hifi_img->sections[i].sn,\
+						hifi_img->sections[i].src_offset,\
+						hifi_img->sections[i].type);
+
+		remap_dest_addr = (unsigned long)hifi_img->sections[i].des_addr;
+		if (remap_dest_addr >= HIFI_OCRAM_PHY_BEGIN_ADDR && remap_dest_addr <= HIFI_OCRAM_PHY_END_ADDR) {
+			index = 2;
+		} else if (remap_dest_addr >= HIFI_TCM_PHY_BEGIN_ADDR && remap_dest_addr <= HIFI_TCM_PHY_END_ADDR) {
+			index = 1;
+		}
+		else { //(remap_addr >= HIFI_DDR_PHY_BEGIN_ADDR && remap_addr <= HIFI_DDR_PHY_END_ADDR)
+			index = 0;
+		}
+		remap_dest_addr -= addr_remap_tables[index].phy_addr_start - addr_remap_tables[index].remap_addr;
+
+		if (DRV_HIFI_IMAGE_SEC_TYPE_BSS != hifi_img->sections[i].type) {
+			unsigned int * iomap_dest_addr = NULL;
+
+			if ((unsigned char)DRV_HIFI_IMAGE_SEC_UNLOAD == hifi_img->sections[i].load_attib) {
+				logi("unload section\n");
+				continue;
+			}
+
+			iomap_dest_addr = (unsigned int*)ioremap(remap_dest_addr, hifi_img->sections[i].size);
+			if (!iomap_dest_addr) {
+				loge("ioremap failed\n");
+				vfree(img_buf);
+				return -1;
+			}
+			memcpy_aligned((void*)(iomap_dest_addr),
+				(void*)((char*)hifi_img + hifi_img->sections[i].src_offset),
+				hifi_img->sections[i].size);
+			iounmap(iomap_dest_addr);
+		}
+	}
+
+	vfree(img_buf);
+
+	return 0;
+}
+
 #define RESET_OPTION_LEN 100
 
 static ssize_t hifi_dsp_reset_option_show(struct file *file, char __user *buf,
@@ -811,6 +1053,11 @@ static ssize_t hifi_dsp_reset_option_show(struct file *file, char __user *buf,
 		loge("Input param buf is invalid\n");
 		return -EINVAL;
 	}
+	if (load_hifi_img_by_misc() == 0){
+		g_om_data.dsp_loaded = true;
+        read_hifi_shared_addr();
+        loge("g_om_data.dsp_loaded:%d\n",(int)g_om_data.dsp_loaded);
+    }
 
 	snprintf(reset_option, RESET_OPTION_LEN,
 		"reset_option: 0(reset mediasever) 1(reset system) current:%d.\n", g_om_data.reset_system);
@@ -1104,15 +1351,15 @@ void hifi_om_init(struct platform_device *pdev, unsigned char* hifi_priv_base_vi
 	g_om_data.dsp_debug_level = 2; /*info level*/
 	g_om_data.first_dump_log = true;
 
-	g_om_data.dsp_panic_mark = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_PANIC_MARK - HIFI_BASE_ADDR));
-	g_om_data.dsp_bin_addr = (char*)(hifi_priv_base_virt + (HIFI_DUMP_BIN_ADDR - HIFI_BASE_ADDR));
-	g_om_data.dsp_exception_no = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_EXCEPTION_NO - HIFI_BASE_ADDR));
-	g_om_data.dsp_log_cur_addr = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_UART_TO_MEM_CUR_ADDR - HIFI_BASE_ADDR));
-	g_om_data.dsp_log_addr = NULL;
+	g_om_data.dsp_panic_mark = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_PANIC_MARK - HIFI_UNSEC_BASE_ADDR));
+	g_om_data.dsp_bin_addr = (char*)(hifi_priv_base_virt + (HIFI_DUMP_BIN_ADDR - HIFI_UNSEC_BASE_ADDR));
+	g_om_data.dsp_exception_no = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_EXCEPTION_NO - HIFI_UNSEC_BASE_ADDR));
+	g_om_data.dsp_log_cur_addr = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_UART_TO_MEM_CUR_ADDR - HIFI_UNSEC_BASE_ADDR));
+	g_om_data.dsp_log_addr = (char *)(hifi_priv_base_virt + (DRV_DSP_UART_TO_MEM - HIFI_UNSEC_BASE_ADDR));
 	*g_om_data.dsp_log_cur_addr = DRV_DSP_UART_TO_MEM_RESERVE_SIZE;
 
-	g_om_data.dsp_debug_level_addr = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_UART_LOG_LEVEL - HIFI_BASE_ADDR));
-	g_om_data.dsp_debug_kill_addr = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_KILLME_ADDR - HIFI_BASE_ADDR));
+	g_om_data.dsp_debug_level_addr = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_UART_LOG_LEVEL - HIFI_UNSEC_BASE_ADDR));
+	g_om_data.dsp_debug_kill_addr = (unsigned int*)(hifi_priv_base_virt + (DRV_DSP_KILLME_ADDR - HIFI_UNSEC_BASE_ADDR));
 
 	*(g_om_data.dsp_exception_no) = ~0;
 	g_om_data.pre_exception_no = ~0;

--- a/drivers/hisi/hifidsp/hifi_om.h
+++ b/drivers/hisi/hifidsp/hifi_om.h
@@ -46,6 +46,7 @@ extern "C" {
 #define HIFI_OM_FILE_LIMIT		0640
 #define HIFI_OM_LOG_SIZE_MAX	0x400000 /* 4*1024*1024 = 4M */
 #define HIFI_OM_FILE_BUFFER_SIZE_MAX	(1024)
+#define HIFI_SEC_MAX_NUM 64
 
 typedef enum {
 	DUMP_DSP_LOG,
@@ -139,6 +140,47 @@ enum EFFECT_STREAM_ID{
 	AUDIO_STREAM_VOICEPP_INPUT,
 	AUDIO_STREAM_INPUT_CNT,
 };
+
+enum DRV_HIFI_IMAGE_SEC_LOAD_ENUM {
+	DRV_HIFI_IMAGE_SEC_LOAD_STATIC = 0,
+	DRV_HIFI_IMAGE_SEC_LOAD_DYNAMIC,
+	DRV_HIFI_IMAGE_SEC_UNLOAD,
+	DRV_HIFI_IMAGE_SEC_UNINIT,
+	DRV_HIFI_IMAGE_SEC_LOAD_BUTT,
+};
+typedef unsigned char DRV_HIFI_IMAGE_SEC_LOAD_ENUM_UINT8;
+
+enum DRV_HIFI_IMAGE_SEC_TYPE_ENUM {
+	DRV_HIFI_IMAGE_SEC_TYPE_CODE = 0,
+	DRV_HIFI_IMAGE_SEC_TYPE_DATA,
+	DRV_HIFI_IMAGE_SEC_TYPE_BSS,
+	DRV_HIFI_IMAGE_SEC_TYPE_BUTT,
+};
+typedef unsigned char DRV_HIFI_IMAGE_SEC_TYPE_ENUM_UINT8;
+
+struct drv_hifi_image_sec {
+	unsigned short sn;
+	DRV_HIFI_IMAGE_SEC_TYPE_ENUM_UINT8 type;
+	DRV_HIFI_IMAGE_SEC_LOAD_ENUM_UINT8 load_attib;
+	unsigned int src_offset;
+	unsigned int des_addr;
+	unsigned int size;
+};
+
+struct drv_hifi_image_head {
+	char time_stamp[24];
+	unsigned int image_size;
+	unsigned int sections_num;
+	struct drv_hifi_image_sec sections[HIFI_SEC_MAX_NUM];
+};
+
+struct image_partition_table{
+	unsigned long phy_addr_start;
+	unsigned long phy_addr_end;
+	unsigned int size;
+	unsigned long remap_addr;
+};
+
 
 struct hifi_om_s {
 	struct task_struct* kdumpdsp_task;

--- a/drivers/hisi/hifidsp/memcpy_opt.S
+++ b/drivers/hisi/hifidsp/memcpy_opt.S
@@ -1,0 +1,21 @@
+    .global  memcpy128
+    .global  memcpy64
+
+memcpy128:
+    add	x2, x0, x2
+memcpy_align_128:
+    ldp	x3, x4, [x1], #16
+    stp	x3, x4, [x0], #16
+    cmp	x0, x2
+    b.ne	memcpy_align_128
+    ret
+
+memcpy64:
+    add	x2, x0, x2
+memcpy_align_64:
+    ldr	x3, [x1], #8
+    str	x3, [x0], #8
+    cmp	x0, x2
+    b.ne	memcpy_align_64
+    ret
+


### PR DESCRIPTION
Please merge below commit only to 96boards-hikey:working-android-hikey-linaro-4.4-hifi-dsp

commit 6eb398bf1d803e0fcddd310cb70d93a33622c3a0
Author: Niranjan Yadla <nyadla@cadence.com>
Date:   Fri May 12 10:55:49 2017 -0700

    Cadence Ported from HiSilicon patch:loadhifi image
    
    1.1 Notify lpm3 to reset hifi
    1.2 read hifi firmware image from /data/hifi.img
    1.3 load sections on to dsp instruction memory
    1.4 Added read_hifi_shared_addr() to read and log value at 0x8ACC5000 addr.
        DSP is supposed to modify this 0x8ACC5000 addr with specific value:0x5a5a5a5a
