### PR TITLE
PCI: kirin: Fix reset gpio name

### DIFF
--- a/drivers/pci/dwc/pcie-kirin.c
+++ b/drivers/pci/dwc/pcie-kirin.c
@@ -490,7 +490,7 @@ static int kirin_pcie_probe(struct platform_device *pdev)
 		return ret;
 
 	kirin_pcie->gpio_id_reset = of_get_named_gpio(dev->of_node,
-						      "reset-gpio", 0);
+						      "reset-gpios", 0);
 	if (kirin_pcie->gpio_id_reset < 0)
 		return -ENODEV;
 


### PR DESCRIPTION
As documented in the device-tree bindings (pci/kirin-pcie.txt) and
defined in existing device-tree (hi3660.dtsi), the reset gpio name
is 'reset-gpios'. However, driver looks for a 'reset-gpio' resource
which makes the driver probe fail. Fix this.

Fixes: fc5165db245a ("PCI: kirin: Add HiSilicon Kirin SoC PCIe controller driver")
Signed-off-by: Loic Poulain <loic.poulain@linaro.org>
Acked-by: Xiaowei Song <songxiaowei@hisilicon.com>